### PR TITLE
feat: replace emojis with react icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/src/components/DMLog.tsx
+++ b/src/components/DMLog.tsx
@@ -1,5 +1,35 @@
 import { useEffect, useRef } from "react";
+import type { IconType } from "react-icons";
+import {
+  GiSkullCrossedBones,
+  GiUpgrade,
+  GiCrossedSwords,
+  GiPuzzle,
+  GiHeartPlus,
+  GiExplosionRays,
+  GiMagicSwirl,
+  GiShield,
+  GiBleedingWound,
+  GiFireball,
+  GiLightningTrio,
+  GiHealing,
+} from "react-icons/gi";
 import { useGameStore } from "../store/useGameStore";
+
+const ICONS: Partial<Record<string, IconType>> = {
+  "☠️": GiSkullCrossedBones,
+  "🔺": GiUpgrade,
+  "⚔️": GiCrossedSwords,
+  "🧩": GiPuzzle,
+  "💚": GiHeartPlus,
+  "💥": GiExplosionRays,
+  "🔮": GiMagicSwirl,
+  "🛡️": GiShield,
+  "💢": GiBleedingWound,
+  "🔥": GiFireball,
+  "⚡": GiLightningTrio,
+  "✨": GiHealing,
+};
 
 export default function DMLog() {
   const log = useGameStore(s => s.log);
@@ -13,9 +43,17 @@ export default function DMLog() {
     <div className="p-3 rounded-2xl bg-slate-800/40 border border-slate-800 h-64 overflow-auto" ref={ref}>
       <div className="text-sm font-semibold mb-2">Dungeon Master Log</div>
       <ul className="space-y-1 text-sm">
-        {log.map((line, i) => (
-          <li key={i} className="text-slate-300">{line}</li>
-        ))}
+        {log.map((line, i) => {
+          const [symbol, ...rest] = line.split(" ");
+          const Icon = ICONS[symbol];
+          const text = Icon ? rest.join(" ") : line;
+          return (
+            <li key={i} className="text-slate-300 flex items-center gap-1">
+              {Icon ? <Icon /> : null}
+              <span>{text}</span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/Piece.tsx
+++ b/src/components/Piece.tsx
@@ -1,9 +1,24 @@
 import type { Piece } from "../game/types";
 import { baseStats } from "../game/chess";
 import { cx } from "../utils/cx";
+import type { IconType } from "react-icons";
+import {
+  GiChessKing,
+  GiChessQueen,
+  GiChessRook,
+  GiChessBishop,
+  GiChessKnight,
+  GiChessPawn,
+  GiShield,
+} from "react-icons/gi";
 
-const ICONS: Record<Piece["type"], string> = {
-  king: "♔", queen: "♕", rook: "♖", bishop: "♗", knight: "♘", pawn: "♙",
+const ICONS: Record<Piece["type"], IconType> = {
+  king: GiChessKing,
+  queen: GiChessQueen,
+  rook: GiChessRook,
+  bishop: GiChessBishop,
+  knight: GiChessKnight,
+  pawn: GiChessPawn,
 };
 
 export default function PieceView({ piece }: { piece: Piece }) {
@@ -14,16 +29,22 @@ export default function PieceView({ piece }: { piece: Piece }) {
     ? "drop-shadow-[0_0_6px_rgba(255,255,255,0.5)]"
     : "drop-shadow-[0_0_6px_rgba(0,0,0,0.5)]";
 
+  const Icon = ICONS[piece.type];
+
   return (
     <div className={cx("absolute inset-0 flex items-center justify-center text-4xl", glow)}>
       <div className={cx("relative", fg)}>
-        <span>{ICONS[piece.type]}</span>
+        <Icon />
         <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 w-12 h-2 bg-slate-700 rounded">
-          <div className="h-2 rounded bg-emerald-500" style={{ width: `${hpPct}%` }} title={`HP: ${piece.hp}/${max}`} />
+          <div
+            className="h-2 rounded bg-emerald-500"
+            style={{ width: `${hpPct}%` }}
+            title={`HP: ${piece.hp}/${max}`}
+          />
         </div>
         {!!piece.shield && (
-          <div className="absolute -top-3 left-1/2 -translate-x-1/2 text-[10px] bg-indigo-600 px-1 rounded">
-            🛡 {piece.shield}
+          <div className="absolute -top-3 left-1/2 -translate-x-1/2 text-[10px] bg-indigo-600 px-1 rounded flex items-center gap-0.5">
+            <GiShield /> {piece.shield}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- swap chess piece glyphs and shield emoji for `react-icons` game icons
- render DM log entries with matching `react-icons` instead of emoji
- add `react-icons` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4169b54fc833284541c3021187d6a