### PR TITLE
feat: fullscreen game layout with dnd icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import AbilityBar from "./components/AbilityBar";
 
 export default function App() {
   return (
-    <div className="min-h-full grid grid-rows-[auto_1fr_auto] bg-slate-900 text-slate-100 antialiased">
+    <div className="h-screen grid grid-rows-[auto_1fr_auto] bg-slate-900 text-slate-100 antialiased">
       <header className="p-4 border-b border-slate-800 sticky top-0 z-10 bg-slate-900/80 backdrop-blur">
         <h1 className="text-xl font-bold">🧙 Wizards of the Grid</h1>
         <p className="text-sm text-slate-400">

--- a/src/components/Piece.tsx
+++ b/src/components/Piece.tsx
@@ -3,22 +3,22 @@ import { baseStats } from "../game/chess";
 import { cx } from "../utils/cx";
 import type { IconType } from "react-icons";
 import {
-  GiChessKing,
-  GiChessQueen,
-  GiChessRook,
-  GiChessBishop,
-  GiChessKnight,
-  GiChessPawn,
+  GiWizardStaff,
+  GiSpellBook,
+  GiStoneTower,
+  GiHolySymbol,
+  GiMountedKnight,
+  GiPointySword,
   GiShield,
 } from "react-icons/gi";
 
 const ICONS: Record<Piece["type"], IconType> = {
-  king: GiChessKing,
-  queen: GiChessQueen,
-  rook: GiChessRook,
-  bishop: GiChessBishop,
-  knight: GiChessKnight,
-  pawn: GiChessPawn,
+  king: GiWizardStaff,
+  queen: GiSpellBook,
+  rook: GiStoneTower,
+  bishop: GiHolySymbol,
+  knight: GiMountedKnight,
+  pawn: GiPointySword,
 };
 
 export default function PieceView({ piece }: { piece: Piece }) {
@@ -32,8 +32,13 @@ export default function PieceView({ piece }: { piece: Piece }) {
   const Icon = ICONS[piece.type];
 
   return (
-    <div className={cx("absolute inset-0 flex items-center justify-center text-4xl", glow)}>
-      <div className={cx("relative", fg)}>
+    <div
+      className={cx(
+        "absolute inset-0 flex items-center justify-center text-4xl transition-transform duration-300",
+        glow,
+      )}
+    >
+      <div className={cx("relative transform hover:scale-110 hover:-translate-y-1", fg)}>
         <Icon />
         <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 w-12 h-2 bg-slate-700 rounded">
           <div


### PR DESCRIPTION
## Summary
- make app fill the viewport height
- replace chess piece icons with DnD styled icons and add hover animation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a41a906c748332a17d69f3b574cab0