### PR TITLE
feat: add theme toggle and game controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,32 +2,46 @@ import Board from "./components/Board";
 import HUD from "./components/HUD";
 import DMLog from "./components/DMLog";
 import AbilityBar from "./components/AbilityBar";
+import { useState } from "react";
 
 export default function App() {
+  const [theme, setTheme] = useState<"light" | "dark">("dark");
   return (
-    <div className="h-screen grid grid-rows-[auto_1fr_auto] bg-slate-900 text-slate-100 antialiased">
-      <header className="p-4 border-b border-slate-800 sticky top-0 z-10 bg-slate-900/80 backdrop-blur">
-        <h1 className="text-xl font-bold">🧙 Wizards of the Grid</h1>
-        <p className="text-sm text-slate-400">
-          DnD-geïnspireerd schaken. HP, abilities, cooldowns. Minder zout, meer vuurballen.
-        </p>
-      </header>
+    <div className={theme === "dark" ? "dark h-screen" : "h-screen"}>
+      <div className="grid h-full grid-rows-[auto_1fr_auto] bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100 antialiased">
+        <header className={`p-4 border-b sticky top-0 z-10 backdrop-blur ${theme === "dark" ? "border-slate-800 bg-slate-900/80" : "border-slate-200 bg-white/80"}`}>
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-xl font-bold">🧙 Wizards of the Grid</h1>
+              <p className="text-sm text-slate-400">
+                DnD-geïnspireerd schaken. HP, abilities, cooldowns. Minder zout, meer vuurballen.
+              </p>
+            </div>
+            <button
+              className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100"
+              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            >
+              {theme === "dark" ? "Light" : "Dark"} mode
+            </button>
+          </div>
+        </header>
 
-      <main className="p-4 grid gap-4 md:grid-cols-[1fr_320px]">
-        <div className="rounded-2xl p-3 bg-slate-800/40 border border-slate-800 shadow-[0_8px_30px_rgba(0,0,0,0.08)]">
-          <Board />
-        </div>
+        <main className="p-4 grid gap-4 md:grid-cols-[1fr_320px]">
+          <div className="rounded-2xl p-3 border shadow-[0_8px_30px_rgba(0,0,0,0.08)] bg-slate-100/40 border-slate-200 dark:bg-slate-800/40 dark:border-slate-800">
+            <Board />
+          </div>
 
-        <div className="flex flex-col gap-4">
-          <HUD />
-          <AbilityBar />
-          <DMLog />
-        </div>
-      </main>
+          <div className="flex flex-col gap-4">
+            <HUD />
+            <AbilityBar />
+            <DMLog />
+          </div>
+        </main>
 
-      <footer className="p-4 text-center text-xs text-slate-500">
-        © {new Date().getFullYear()} Wizards of the Grid. Gemaakt in React + Tailwind.
-      </footer>
+        <footer className="p-4 text-center text-xs text-slate-600 dark:text-slate-500">
+          © {new Date().getFullYear()} Wizards of the Grid. Gemaakt in React + Tailwind.
+        </footer>
+      </div>
     </div>
   );
 }

--- a/src/components/AbilityBar.tsx
+++ b/src/components/AbilityBar.tsx
@@ -12,14 +12,14 @@ export default function AbilityBar() {
 
   if (!piece) {
     return (
-      <div className="p-3 rounded-2xl bg-slate-800/40 border border-slate-800">
-        <div className="text-sm text-slate-400">Selecteer een stuk om abilities te zien.</div>
+      <div className="p-3 rounded-2xl bg-slate-100/40 border border-slate-200 dark:bg-slate-800/40 dark:border-slate-800">
+        <div className="text-sm text-slate-600 dark:text-slate-400">Selecteer een stuk om abilities te zien.</div>
       </div>
     );
   }
 
   return (
-    <div className="p-3 rounded-2xl bg-slate-800/40 border border-slate-800">
+    <div className="p-3 rounded-2xl bg-slate-100/40 border border-slate-200 dark:bg-slate-800/40 dark:border-slate-800">
       <div className="text-sm font-semibold mb-2">Abilities</div>
       <div className="flex flex-wrap gap-2">
         {available.map(a => {
@@ -32,7 +32,9 @@ export default function AbilityBar() {
               className={[
                 "px-3 py-1.5 rounded-lg text-sm transition",
                 active ? "ring-2 ring-emerald-400" : "",
-                disabled ? "opacity-50 cursor-not-allowed" : "bg-slate-700 hover:bg-slate-600"
+                disabled
+                  ? "opacity-50 cursor-not-allowed"
+                  : "bg-slate-200 hover:bg-slate-300 text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100",
               ].join(" ")}
               onClick={() => !disabled && setAbility(active ? undefined : a.id)}
               title={a.desc}
@@ -42,7 +44,7 @@ export default function AbilityBar() {
           );
         })}
       </div>
-      <div className="text-xs text-slate-400 mt-2">Tip: Ability selecteren, klik daarna op doel-tegel.</div>
+      <div className="text-xs text-slate-600 dark:text-slate-400 mt-2">Tip: Ability selecteren, klik daarna op doel-tegel.</div>
     </div>
   );
 }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -9,9 +9,10 @@ export default function Board() {
   const legalMoves = useGameStore(s => s.legalMoves);
   const selected = useGameStore(s => s.selected);
   const selectSquare = useGameStore(s => s.selectSquare);
+  const status = useGameStore(s => s.status);
 
   return (
-    <div className="relative grid grid-cols-8 aspect-square rounded-xl overflow-hidden border border-slate-700">
+    <div className="relative grid grid-cols-8 aspect-square rounded-xl overflow-hidden border border-slate-300 dark:border-slate-700">
       {board.map((sq, i) => {
         const isLight = (sq.coord.x + sq.coord.y) % 2 === 0;
         const on = () => selectSquare(sq.coord);
@@ -22,7 +23,7 @@ export default function Board() {
         return (
           <div
             key={i}
-            onClick={on}
+            onClick={status === "running" ? on : undefined}
             className={cx(
               "relative cursor-pointer select-none",
               isLight ? "bg-boardLight" : "bg-boardDark",
@@ -34,6 +35,11 @@ export default function Board() {
           </div>
         );
       })}
+      {status !== "running" && (
+        <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white">
+          {status === "idle" ? "Start het spel." : "Spel beëindigd."}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/DMLog.tsx
+++ b/src/components/DMLog.tsx
@@ -40,7 +40,10 @@ export default function DMLog() {
   }, [log]);
 
   return (
-    <div className="p-3 rounded-2xl bg-slate-800/40 border border-slate-800 h-64 overflow-auto" ref={ref}>
+    <div
+      className="p-3 rounded-2xl bg-slate-100/40 border border-slate-200 dark:bg-slate-800/40 dark:border-slate-800 h-64 overflow-auto"
+      ref={ref}
+    >
       <div className="text-sm font-semibold mb-2">Dungeon Master Log</div>
       <ul className="space-y-1 text-sm">
         {log.map((line, i) => {
@@ -48,7 +51,7 @@ export default function DMLog() {
           const Icon = ICONS[symbol];
           const text = Icon ? rest.join(" ") : line;
           return (
-            <li key={i} className="text-slate-300 flex items-center gap-1">
+            <li key={i} className="text-slate-700 dark:text-slate-300 flex items-center gap-1">
               {Icon ? <Icon /> : null}
               <span>{text}</span>
             </li>

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -6,17 +6,20 @@ export default function HUD() {
   const selected = useGameStore(s => s.selected);
   const piece = useGameStore(s => (selected ? s.pieces[selected] : undefined));
   const endTurn = useGameStore(s => s.endTurn);
-  const reset = useGameStore(s => s.reset);
+  const startGame = useGameStore(s => s.startGame);
+  const endGame = useGameStore(s => s.endGame);
+  const restartGame = useGameStore(s => s.restartGame);
+  const status = useGameStore(s => s.status);
 
   const abilities = piece ? ABILITIES.filter(a => !a.pieceTypes || a.pieceTypes.includes(piece.type)) : [];
 
   return (
-    <div className="p-3 rounded-2xl bg-slate-800/40 border border-slate-800 shadow-[0_8px_30px_rgba(0,0,0,0.08)]">
+    <div className="p-3 rounded-2xl bg-slate-100/40 border border-slate-200 shadow-[0_8px_30px_rgba(0,0,0,0.08)] dark:bg-slate-800/40 dark:border-slate-800">
       <div className="flex items-center justify-between mb-2">
         <div className="text-sm">
           <div className="font-semibold">Beurt: {turn}</div>
           {piece ? (
-            <div className="text-slate-400">
+            <div className="text-slate-600 dark:text-slate-400">
               Geselecteerd: <span className="font-mono">{piece.id}</span> ({piece.type})
               {" · "}HP {piece.hp}
               {" · "}XP {piece.xp}
@@ -25,13 +28,22 @@ export default function HUD() {
             <div className="text-slate-500">Geen stuk geselecteerd.</div>
           )}
         </div>
-        <div className="flex gap-2">
-          <button className="px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm" onClick={endTurn}>Einde beurt</button>
-          <button className="px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm" onClick={reset}>Reset</button>
+        <div className="flex gap-2 flex-wrap justify-end">
+          {status === "running" ? (
+            <>
+              <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={endTurn}>Einde beurt</button>
+              <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={restartGame}>Herstart</button>
+              <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={endGame}>Stop</button>
+            </>
+          ) : (
+            <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={status === "idle" ? startGame : restartGame}>
+              {status === "idle" ? "Start" : "Opnieuw"}
+            </button>
+          )}
         </div>
       </div>
       {piece && abilities.length > 0 && (
-        <div className="text-xs text-slate-400">Abilities: {abilities.map(a => a.name).join(", ")}</div>
+        <div className="text-xs text-slate-600 dark:text-slate-400">Abilities: {abilities.map(a => a.name).join(", ")}</div>
       )}
     </div>
   );

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -32,6 +32,8 @@ export interface Square {
   pieceId?: string;
 }
 
+export type GameStatus = "idle" | "running" | "ended";
+
 export interface GameState {
   board: Square[];
   pieces: Record<string, Piece>;
@@ -40,6 +42,7 @@ export interface GameState {
   selectedAbility?: string; // abilityId
   legalMoves: Coord[];
   log: string[];
+  status: GameStatus;
 }
 
 export type ApplyResult = {

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { castAbility, canCastAbility } from "../game/abilities";
-import type { ApplyResult, Coord, Faction, GameState } from "../game/types";
+import type { ApplyResult, Coord, Faction, GameState, Piece } from "../game/types";
 import { baseStats, getSquare, idx, initialPieces, initialTerrain, isEnemy, legalMoves, rebuildBoard } from "../game/chess";
 
 type Actions = {
@@ -8,10 +8,12 @@ type Actions = {
   selectAbility: (abilityId: string | undefined) => void;
   movePiece: (to: Coord) => void;
   endTurn: () => void;
-  reset: () => void;
+  startGame: () => void;
+  endGame: () => void;
+  restartGame: () => void;
 };
 
-const initialState = (): GameState => {
+const createGameState = (): GameState => {
   const board = initialTerrain();
   const pieces = initialPieces();
   const state: GameState = {
@@ -22,19 +24,40 @@ const initialState = (): GameState => {
     selectedAbility: undefined,
     legalMoves: [],
     log: ["Spel gestart. White begint."],
+    status: "running",
+  };
+  rebuildBoard(state.board, state.pieces);
+  return state;
+};
+
+const idleState = (): GameState => {
+  const board = initialTerrain();
+  const pieces: Record<string, Piece> = {};
+  const state: GameState = {
+    board,
+    pieces,
+    turn: "white",
+    selected: undefined,
+    selectedAbility: undefined,
+    legalMoves: [],
+    log: ["Klik start om te beginnen."],
+    status: "idle",
   };
   rebuildBoard(state.board, state.pieces);
   return state;
 };
 
 export const useGameStore = create<GameState & Actions>((set, get) => ({
-  ...initialState(),
+  ...idleState(),
 
-  reset: () => set(initialState()),
+  startGame: () => set(createGameState()),
+  endGame: () => set({ status: "ended", log: [...get().log, "Spel beëindigd."] }),
+  restartGame: () => set(createGameState()),
   selectAbility: (abilityId) => set({ selectedAbility: abilityId }),
 
   selectSquare: (coord) => {
     const state = get();
+    if (state.status !== "running") return;
     const sq = getSquare(state.board, coord);
     if (!sq) return;
 
@@ -66,6 +89,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
 
   movePiece: (to) => {
     const state = get();
+    if (state.status !== "running") return;
     if (!state.selected) return;
     const piece = state.pieces[state.selected];
     const allowed = state.legalMoves.some(m => m.x === to.x && m.y === to.y);
@@ -127,6 +151,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
 
   endTurn: () => {
     const state = get();
+    if (state.status !== "running") return;
     for (const p of Object.values(state.pieces)) {
       for (const key of Object.keys(p.cooldowns)) p.cooldowns[key] = Math.max(0, p.cooldowns[key] - 1);
     }


### PR DESCRIPTION
## Summary
- add light/dark theme toggle and adjust component styling
- enable manual game start, stop, and restart with new HUD controls
- disable board interactions when game inactive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a41c85808483328d4f62b2af75c2ee