### PR TITLE
feat: add dnd board theme and responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,8 +26,8 @@ export default function App() {
           </div>
         </header>
 
-        <main className="p-4 grid gap-4 md:grid-cols-[1fr_320px]">
-          <div className="rounded-2xl p-3 border shadow-[0_8px_30px_rgba(0,0,0,0.08)] bg-slate-100/40 border-slate-200 dark:bg-slate-800/40 dark:border-slate-800">
+        <main className="p-4 grid gap-4 md:grid-cols-[1fr_320px] h-full">
+          <div className="rounded-2xl p-3 border shadow-[0_8px_30px_rgba(0,0,0,0.08)] bg-slate-100/40 border-slate-200 dark:bg-slate-800/40 dark:border-slate-800 flex items-center justify-center h-full">
             <Board />
           </div>
 

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -12,7 +12,7 @@ export default function Board() {
   const status = useGameStore(s => s.status);
 
   return (
-    <div className="relative grid grid-cols-8 aspect-square rounded-xl overflow-hidden border border-slate-300 dark:border-slate-700">
+    <div className="relative grid grid-cols-8 h-full max-w-full aspect-square rounded-xl overflow-hidden border border-slate-300 dark:border-slate-700">
       {board.map((sq, i) => {
         const isLight = (sq.coord.x + sq.coord.y) % 2 === 0;
         const on = () => selectSquare(sq.coord);
@@ -25,8 +25,8 @@ export default function Board() {
             key={i}
             onClick={status === "running" ? on : undefined}
             className={cx(
-              "relative cursor-pointer select-none",
-              isLight ? "bg-boardLight" : "bg-boardDark",
+              "relative cursor-pointer select-none bg-cover",
+              isLight ? "bg-dnd-light dark:bg-dnd-light-dark" : "bg-dnd-dark dark:bg-dnd-dark-dark",
               "hover:brightness-110"
             )}
           >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,16 @@ export default {
         heal: "#16a34a",
         trap: "#dc2626",
       },
+      backgroundImage: {
+        "dnd-light":
+          "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 40 40\'%3E%3Crect width=\'40\' height=\'40\' fill=\'%23f2e9d6\'/%3E%3Cpath d=\'M0 0L40 40M40 0L0 40\' stroke=\'%23d3c4a3\' stroke-width=\'2\' opacity=\'0.2\'/%3E%3C/svg%3E')",
+        "dnd-dark":
+          "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 40 40\'%3E%3Crect width=\'40\' height=\'40\' fill=\'%234b3621\'/%3E%3Cpath d=\'M0 0L40 40M40 0L0 40\' stroke=\'%233a2a18\' stroke-width=\'2\' opacity=\'0.2\'/%3E%3C/svg%3E')",
+        "dnd-light-dark":
+          "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 40 40\'%3E%3Crect width=\'40\' height=\'40\' fill=\'%233a2f22\'/%3E%3Cpath d=\'M0 0L40 40M40 0L0 40\' stroke=\'%232c2318\' stroke-width=\'2\' opacity=\'0.2\'/%3E%3C/svg%3E')",
+        "dnd-dark-dark":
+          "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 40 40\'%3E%3Crect width=\'40\' height=\'40\' fill=\'%231e1b16\'/%3E%3Cpath d=\'M0 0L40 40M40 0L0 40\' stroke=\'%232a2217\' stroke-width=\'2\' opacity=\'0.2\'/%3E%3C/svg%3E')",
+      },
       boxShadow: { soft: "0 8px 30px rgba(0,0,0,0.08)" },
     },
   },


### PR DESCRIPTION
## Summary
- add procedurally generated DnD-style textures for light and dark squares
- center board and size it to remaining viewport to avoid scrolling
- ensure board squares switch textures in dark mode

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4206577c88332815f748a98009ff0