### PR TITLE
feat: allow player color selection

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -147,7 +147,7 @@ export default function Board() {
 
       {status !== "running" && (
         <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white">
-          {status === "idle" ? "Start het spel." : "Spel beëindigd."}
+          {status === "idle" ? "Kies een kleur om te starten." : "Spel beëindigd."}
         </div>
       )}
     </div>

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -10,6 +10,7 @@ export default function HUD() {
   const endGame = useGameStore(s => s.endGame);
   const restartGame = useGameStore(s => s.restartGame);
   const status = useGameStore(s => s.status);
+  const player = useGameStore(s => s.player);
 
   const fogEnabled = useGameStore(s => s.fogEnabled);
   const visionRange = useGameStore(s => s.visionRange);
@@ -25,6 +26,7 @@ export default function HUD() {
       <div className="flex items-center justify-between mb-2">
         <div className="text-sm">
           <div className="font-semibold">Beurt: {turn}</div>
+          <div className="text-slate-600 dark:text-slate-400">Speler: {player}</div>
           {piece ? (
             <div className="text-slate-600 dark:text-slate-400">
               Geselecteerd: <span className="font-mono">{piece.id}</span> ({piece.type})
@@ -42,10 +44,13 @@ export default function HUD() {
               <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={restartGame}>Herstart</button>
               <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={endGame}>Stop</button>
             </>
+          ) : status === "idle" ? (
+            <>
+              <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={() => startGame("white")}>Start wit</button>
+              <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={() => startGame("black")}>Start zwart</button>
+            </>
           ) : (
-            <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={status === "idle" ? startGame : restartGame}>
-              {status === "idle" ? "Start" : "Opnieuw"}
-            </button>
+            <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={restartGame}>Opnieuw</button>
           )}
         </div>
       </div>

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -53,6 +53,7 @@ export interface GameState {
   board: Square[];
   pieces: Record<string, Piece>;
   turn: Faction;
+  player: Faction;
   status: GameStatus;
   selected?: string;        // pieceId
   selectedAbility?: string; // abilityId

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -8,7 +8,7 @@ type Actions = {
   selectAbility: (abilityId: string | undefined) => void;
   movePiece: (to: Coord) => void;
   endTurn: () => void;
-  startGame: () => void;
+  startGame: (faction: Faction) => void;
   endGame: () => void;
   restartGame: () => void;
 
@@ -18,18 +18,19 @@ type Actions = {
   setPerPieceVisionEnabled: (on: boolean) => void;
 };
 
-const createGameState = (): GameState => {
+const createGameState = (player: Faction): GameState => {
   const board = initialTerrain();
   const pieces = initialPieces();
   const state: GameState = {
     board,
     pieces,
-    turn: "white",
+    turn: player,
+    player,
     status: "running",
     selected: undefined,
     selectedAbility: undefined,
     legalMoves: [],
-    log: ["Spel gestart. White begint."],
+    log: [`Spel gestart. ${player} begint.`],
     zones: [],
     fogEnabled: true,
     visionRange: 3,
@@ -46,6 +47,7 @@ const idleState = (): GameState => {
     board,
     pieces,
     turn: "white",
+    player: "white",
     status: "idle",
     selected: undefined,
     selectedAbility: undefined,
@@ -69,9 +71,9 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
   setPerPieceVisionEnabled: (on) => set({ perPieceVisionEnabled: on }),
 
   // Lifecycle
-  startGame: () => set(createGameState()),
+  startGame: (faction) => set(createGameState(faction)),
   endGame: () => set({ status: "ended", log: [...get().log, "Spel beëindigd."] }),
-  restartGame: () => set(createGameState()),
+  restartGame: () => set(state => createGameState(state.player)),
   selectAbility: (abilityId) => set({ selectedAbility: abilityId }),
 
   selectSquare: (coord) => {


### PR DESCRIPTION
## Summary
- allow selecting white or black before starting a game
- track player faction in game state and display it in the HUD
- show color choice prompt when game is idle

## Testing
- `npm run lint` *(fails: Unexpected any in src/components/Piece.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4360e18e4833289fb78a4151a2b78