### PR TITLE
feat: add basic AI opponent

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -27,6 +27,9 @@ export default function HUD() {
         <div className="text-sm">
           <div className="font-semibold">Beurt: {turn}</div>
           <div className="text-slate-600 dark:text-slate-400">Speler: {player}</div>
+          {turn !== player && (
+            <div className="text-slate-600 dark:text-slate-400">Computer is aan zet…</div>
+          )}
           {piece ? (
             <div className="text-slate-600 dark:text-slate-400">
               Geselecteerd: <span className="font-mono">{piece.id}</span> ({piece.type})

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -1,0 +1,23 @@
+import { legalMoves, getSquare, isEnemy } from "./chess";
+import type { GameState, Faction, Coord } from "./types";
+
+export function chooseMove(state: GameState, faction: Faction): { pieceId: string; to: Coord } | null {
+  const candidates = Object.values(state.pieces)
+    .filter(p => p.faction === faction)
+    .map(piece => {
+      const moves = legalMoves(state, piece).filter(m => {
+        const sq = getSquare(state.board, m);
+        if (!sq) return false;
+        if (!sq.pieceId) return true;
+        const target = state.pieces[sq.pieceId];
+        return isEnemy(piece, target);
+      });
+      return { piece, moves };
+    })
+    .filter(entry => entry.moves.length > 0);
+
+  if (candidates.length === 0) return null;
+  const { piece, moves } = candidates[Math.floor(Math.random() * candidates.length)];
+  const to = moves[Math.floor(Math.random() * moves.length)];
+  return { pieceId: piece.id, to };
+}

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { castAbility, canCastAbility } from "../game/abilities";
+import { chooseMove } from "../game/ai";
 import type { ApplyResult, Coord, Faction, GameState, Piece } from "../game/types";
 import { baseStats, getSquare, idx, initialPieces, initialTerrain, isEnemy, legalMoves, rebuildBoard } from "../game/chess";
 
@@ -11,6 +12,7 @@ type Actions = {
   startGame: (faction: Faction) => void;
   endGame: () => void;
   restartGame: () => void;
+  runAiTurn: () => void;
 
   // Nieuwe toggles/instellingen
   setFogEnabled: (on: boolean) => void;
@@ -75,6 +77,21 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
   endGame: () => set({ status: "ended", log: [...get().log, "Spel beëindigd."] }),
   restartGame: () => set(state => createGameState(state.player)),
   selectAbility: (abilityId) => set({ selectedAbility: abilityId }),
+
+  runAiTurn: () => {
+    const state = get();
+    if (state.status !== "running") return;
+    const move = chooseMove(state, state.turn);
+    if (!move) {
+      set({ log: [...state.log, "🤖 geen zet beschikbaar."] });
+      get().endTurn();
+      return;
+    }
+    const log = [...state.log, `🤖 ${move.pieceId} -> (${move.to.x},${move.to.y})`];
+    set({ selected: move.pieceId, legalMoves: [move.to], log });
+    get().movePiece(move.to);
+    get().endTurn();
+  },
 
   selectSquare: (coord) => {
     const state = get();
@@ -253,6 +270,9 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
       log: [...log, `— Einde beurt. ${next} is aan zet.`],
       zones: state.zones,
     });
+    if (next !== state.player) {
+      setTimeout(() => get().runAiTurn(), 500);
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary
- add simple AI move chooser and HUD indicator
- extend game store with `runAiTurn` and AI turn scheduling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/components/Piece.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a438df1350833283388dc75714a52c