### PR TITLE
feat: limit actions to one per turn

### DIFF
--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -60,6 +60,9 @@ export interface GameState {
   legalMoves: Coord[];
   log: string[];
 
+  // Turn state
+  hasMoved: boolean;            // true nadat speler een actie heeft gedaan
+
   // Zones & Fog-of-war
   zones: Zone[];
   fogEnabled: boolean;

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -33,6 +33,7 @@ const createGameState = (player: Faction): GameState => {
     selectedAbility: undefined,
     legalMoves: [],
     log: [`Spel gestart. ${player} begint.`],
+    hasMoved: false,
     zones: [],
     fogEnabled: true,
     visionRange: 3,
@@ -55,6 +56,7 @@ const idleState = (): GameState => {
     selectedAbility: undefined,
     legalMoves: [],
     log: ["Klik start om te beginnen."],
+    hasMoved: false,
     zones: [],
     fogEnabled: true,
     visionRange: 3,
@@ -96,6 +98,10 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
   selectSquare: (coord) => {
     const state = get();
     if (state.status !== "running") return;
+    if (state.hasMoved) {
+      set({ log: [...state.log, "Je mag maar één actie per beurt uitvoeren."] });
+      return;
+    }
     const sq = getSquare(state.board, coord);
     if (!sq) return;
 
@@ -129,6 +135,10 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
     const state = get();
     if (state.status !== "running") return;
     if (!state.selected) return;
+    if (state.hasMoved) {
+      set({ log: [...state.log, "Je mag maar één actie per beurt uitvoeren."] });
+      return;
+    }
 
     const piece = state.pieces[state.selected];
 
@@ -194,7 +204,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
     }
 
     rebuildBoard(state.board, state.pieces);
-    set({ selected: undefined, legalMoves: [], log });
+    set({ selected: undefined, legalMoves: [], log, hasMoved: true });
   },
 
   endTurn: () => {
@@ -269,6 +279,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
       legalMoves: [],
       log: [...log, `— Einde beurt. ${next} is aan zet.`],
       zones: state.zones,
+      hasMoved: false,
     });
     if (next !== state.player) {
       setTimeout(() => get().runAiTurn(), 500);
@@ -299,5 +310,5 @@ function applyResult(
   if (res.damaged) for (const d of res.damaged) log.push(`💢 ${d.id} -${d.amount} HP.`);
 
   rebuildBoard(state.board, state.pieces);
-  set({ selectedAbility: undefined, legalMoves: [], log });
+  set({ selected: undefined, selectedAbility: undefined, legalMoves: [], log, hasMoved: true });
 }


### PR DESCRIPTION
## Summary
- track whether a turn's action has been used with `hasMoved`
- block further moves or ability casts once an action is taken
- reset turn state at end of each turn

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4455983b0833281032489ef4e7ed1