### PR TITLE
feat: add AI difficulty levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 DnD-achtige schaakvariant in React + Vite + Tailwind v4 + Zustand.
 
+De computertegenstander ondersteunt instelbare moeilijkheidsgraden (Makkelijk, Normaal, Moeilijk) via de HUD.
+
 ## Ontwikkelen
 ```bash
 npm i

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from "../store/useGameStore";
 import { ABILITIES } from "../game/abilities";
+import type { AiDifficulty } from "../game/types";
 
 export default function HUD() {
   const turn = useGameStore(s => s.turn);
@@ -18,6 +19,8 @@ export default function HUD() {
   const setFogEnabled = useGameStore(s => s.setFogEnabled);
   const setVisionRange = useGameStore(s => s.setVisionRange);
   const setPerPieceVisionEnabled = useGameStore(s => s.setPerPieceVisionEnabled);
+  const difficulty = useGameStore(s => s.difficulty);
+  const setDifficulty = useGameStore(s => s.setDifficulty);
 
   const abilities = piece ? ABILITIES.filter(a => !a.pieceTypes || a.pieceTypes.includes(piece.type)) : [];
 
@@ -55,6 +58,22 @@ export default function HUD() {
           ) : (
             <button className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100" onClick={restartGame}>Opnieuw</button>
           )}
+        </div>
+      </div>
+
+      {/* AI difficulty */}
+      <div className="mt-3 grid gap-2 sm:grid-cols-3 items-center">
+        <div className="col-span-1 text-xs text-slate-600 dark:text-slate-400">AI Moeilijkheid</div>
+        <div className="col-span-2">
+          <select
+            className="px-2 py-1 rounded-lg bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100 text-sm"
+            value={difficulty}
+            onChange={e => setDifficulty(e.target.value as AiDifficulty)}
+          >
+            <option value="easy">Makkelijk</option>
+            <option value="medium">Normaal</option>
+            <option value="hard">Moeilijk</option>
+          </select>
         </div>
       </div>
 

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -1,9 +1,22 @@
-import { legalMoves, getSquare, isEnemy } from "./chess";
-import type { GameState, Faction, Coord } from "./types";
+import { legalMoves, getSquare, isEnemy, distance } from "./chess";
+import type { GameState, Faction, Coord, AiDifficulty, PieceType } from "./types";
 
-export function chooseMove(state: GameState, faction: Faction): { pieceId: string; to: Coord } | null {
+const PIECE_VALUES: Record<PieceType, number> = {
+  king: 100,
+  queen: 9,
+  rook: 5,
+  bishop: 3,
+  knight: 3,
+  pawn: 1,
+};
+
+export function chooseMove(
+  state: GameState,
+  faction: Faction,
+  difficulty: AiDifficulty
+): { pieceId: string; to: Coord } | null {
   const candidates = Object.values(state.pieces)
-    .filter(p => p.faction === faction)
+    .filter(p => p.faction === faction && (p.stunned ?? 0) === 0)
     .map(piece => {
       const moves = legalMoves(state, piece).filter(m => {
         const sq = getSquare(state.board, m);
@@ -17,6 +30,53 @@ export function chooseMove(state: GameState, faction: Faction): { pieceId: strin
     .filter(entry => entry.moves.length > 0);
 
   if (candidates.length === 0) return null;
+
+  if (difficulty === "easy") {
+    const { piece, moves } = candidates[Math.floor(Math.random() * candidates.length)];
+    const to = moves[Math.floor(Math.random() * moves.length)];
+    return { pieceId: piece.id, to };
+  }
+
+  if (difficulty === "medium") {
+    const captureMoves: { pieceId: string; to: Coord }[] = [];
+    for (const { piece, moves } of candidates) {
+      for (const to of moves) {
+        const targetSq = getSquare(state.board, to);
+        if (targetSq?.pieceId && isEnemy(piece, state.pieces[targetSq.pieceId])) {
+          captureMoves.push({ pieceId: piece.id, to });
+        }
+      }
+    }
+    if (captureMoves.length > 0) {
+      return captureMoves[Math.floor(Math.random() * captureMoves.length)];
+    }
+    const { piece, moves } = candidates[Math.floor(Math.random() * candidates.length)];
+    const to = moves[Math.floor(Math.random() * moves.length)];
+    return { pieceId: piece.id, to };
+  }
+
+  let best: { pieceId: string; to: Coord; score: number } | null = null;
+  const enemies = Object.values(state.pieces).filter(p => p.faction !== faction);
+
+  for (const { piece, moves } of candidates) {
+    for (const to of moves) {
+      const sq = getSquare(state.board, to);
+      const target = sq?.pieceId ? state.pieces[sq.pieceId] : undefined;
+      let score = 0;
+      if (target && isEnemy(piece, target)) {
+        score += PIECE_VALUES[target.type] * 10;
+      }
+      const dists = enemies.map(e => distance(to, e.pos));
+      const minDist = dists.length ? Math.min(...dists) : 0;
+      score -= minDist;
+      if (!best || score > best.score) {
+        best = { pieceId: piece.id, to, score };
+      }
+    }
+  }
+
+  if (best) return { pieceId: best.pieceId, to: best.to };
+
   const { piece, moves } = candidates[Math.floor(Math.random() * candidates.length)];
   const to = moves[Math.floor(Math.random() * moves.length)];
   return { pieceId: piece.id, to };

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,6 +1,7 @@
 export type Faction = "white" | "black";
 export type Terrain = "none" | "heal" | "arcane" | "trap";
 export type PieceType = "king" | "queen" | "rook" | "bishop" | "knight" | "pawn";
+export type AiDifficulty = "easy" | "medium" | "hard";
 
 export type Coord = { x: number; y: number }; // x: 0-7, y: 0-7
 export type GameStatus = "idle" | "running" | "ended";
@@ -68,6 +69,7 @@ export interface GameState {
   fogEnabled: boolean;
   visionRange: number;           // globaal zicht (Chebyshev)
   perPieceVisionEnabled: boolean; // of board per-stuk vision gebruikt
+  difficulty: AiDifficulty;
 }
 
 export type ApplyResult = {

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { castAbility, canCastAbility } from "../game/abilities";
 import { chooseMove } from "../game/ai";
-import type { ApplyResult, Coord, Faction, GameState, Piece } from "../game/types";
+import type { ApplyResult, Coord, Faction, GameState, Piece, AiDifficulty } from "../game/types";
 import { baseStats, getSquare, idx, initialPieces, initialTerrain, isEnemy, legalMoves, rebuildBoard } from "../game/chess";
 
 type Actions = {
@@ -18,6 +18,7 @@ type Actions = {
   setFogEnabled: (on: boolean) => void;
   setVisionRange: (n: number) => void;
   setPerPieceVisionEnabled: (on: boolean) => void;
+  setDifficulty: (d: AiDifficulty) => void;
 };
 
 const createGameState = (player: Faction): GameState => {
@@ -38,6 +39,7 @@ const createGameState = (player: Faction): GameState => {
     fogEnabled: true,
     visionRange: 3,
     perPieceVisionEnabled: true,
+    difficulty: "easy",
   };
   rebuildBoard(state.board, state.pieces);
   return state;
@@ -61,6 +63,7 @@ const idleState = (): GameState => {
     fogEnabled: true,
     visionRange: 3,
     perPieceVisionEnabled: true,
+    difficulty: "easy",
   };
   rebuildBoard(state.board, state.pieces);
   return state;
@@ -73,6 +76,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
   setFogEnabled: (on) => set({ fogEnabled: on }),
   setVisionRange: (n) => set({ visionRange: Math.max(1, Math.min(6, Math.floor(n))) }),
   setPerPieceVisionEnabled: (on) => set({ perPieceVisionEnabled: on }),
+  setDifficulty: (d) => set({ difficulty: d }),
 
   // Lifecycle
   startGame: (faction) => set(createGameState(faction)),
@@ -83,7 +87,7 @@ export const useGameStore = create<GameState & Actions>((set, get) => ({
   runAiTurn: () => {
     const state = get();
     if (state.status !== "running") return;
-    const move = chooseMove(state, state.turn);
+    const move = chooseMove(state, state.turn, state.difficulty);
     if (!move) {
       set({ log: [...state.log, "🤖 geen zet beschikbaar."] });
       get().endTurn();


### PR DESCRIPTION
## Summary
- add AiDifficulty type and state field
- implement easy/medium/hard move selection heuristics
- expose difficulty selector in HUD

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run lint` *(fails: Unexpected any in src/components/Piece.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a45125f71c8332bed2a3c5723d0169