### PR TITLE
feat: add character classes with ancestry perks

### DIFF
--- a/src/components/Piece.tsx
+++ b/src/components/Piece.tsx
@@ -14,21 +14,23 @@ const ICON_OPTIONS: Record<Piece["type"], string[]> = {
   pawn:   ["GiPlainDagger", "GiPointySword", "GiSwordHilt", "GiMagicSwirl"],
 };
 
+const GI = Gi as Record<string, IconType>;
+
 function pickIcon(type: Piece["type"]): IconType {
   const names = ICON_OPTIONS[type];
   for (const name of names) {
-    const Candidate = (Gi as any)[name] as IconType | undefined;
+    const Candidate = GI[name];
     if (Candidate) return Candidate;
   }
-  return (Gi as any).GiMagicSwirl as IconType;
+  return GI.GiMagicSwirl;
 }
 
 // Status icons
 function pickPoisonIcon(): IconType {
-  return (Gi as any).GiPoisonBottle ?? (Gi as any).GiPoisonCloud ?? (Gi as any).GiDeathSkull;
+  return GI.GiPoisonBottle ?? GI.GiPoisonCloud ?? GI.GiDeathSkull;
 }
 function pickStunIcon(): IconType {
-  return (Gi as any).GiPunchBlast ?? (Gi as any).GiStunGrenade ?? (Gi as any).GiLightningTrio;
+  return GI.GiPunchBlast ?? GI.GiStunGrenade ?? GI.GiLightningTrio;
 }
 
 export default function PieceView({ piece, terrain }: { piece: Piece; terrain?: Terrain }) {
@@ -51,9 +53,14 @@ export default function PieceView({ piece, terrain }: { piece: Piece; terrain?: 
     terrain === "arcane" ? "base-aura base-aura--arcane" :
     terrain === "trap"   ? "base-aura base-aura--trap" : "";
 
+  const label = `${piece.options.ancestry} ${piece.options.class}` +
+    (piece.options.subclass ? ` (${piece.options.subclass})` : "") +
+    `\nBackground: ${piece.options.background}` +
+    (piece.options.perks.length ? `\nPerks: ${piece.options.perks.join(",")}` : "");
+
   return (
-    <div className="absolute inset-0 flex items-center justify-center">
-      <div className={cx(baseCls, (piece.stunned ?? 0) > 0 ? "ring-2 ring-yellow-400/60" : "")}>
+    <div className="absolute inset-0 flex items-center justify-center" title={label}>
+      <div className={cx(baseCls, (piece.stunned ?? 0) > 0 ? "ring-2 ring-yellow-400/60" : "")}> 
         {/* Terrain aura rond de base */}
         {auraCls && <div className={auraCls} />}
 

--- a/src/game/abilities.ts
+++ b/src/game/abilities.ts
@@ -185,6 +185,17 @@ export function castAbility(
     res.text = `👁️ ${caster.id} scryt de omgeving.`;
   }
 
+  if (caster.options.perks.includes("blood_pact") && (res.damaged?.length ?? 0) > 0) {
+    const maxHp = baseStats(caster.type).maxHp;
+    caster.hp = Math.min(maxHp, caster.hp + 1);
+    res.healed = [...(res.healed ?? []), { id: caster.id, amount: 1 }];
+    res.text += " 🩸 Blood Pact heelt caster.";
+  }
+
   caster.cooldowns[abilityId] = ability.cooldown;
+  if (caster.options.perks.includes("arcane_engineer")) {
+    caster.cooldowns[abilityId] = Math.max(0, caster.cooldowns[abilityId] - 1);
+    res.text += " ⚙️ Arcane Engineer verkort cooldown.";
+  }
   return res;
 }

--- a/src/game/chess.ts
+++ b/src/game/chess.ts
@@ -1,4 +1,15 @@
-import type { Coord, Piece, PieceType, GameState, Faction, Square } from "./types";
+import type {
+  Coord,
+  Piece,
+  PieceType,
+  GameState,
+  Faction,
+  Square,
+  CharacterOptions,
+  CharacterClass,
+  Ancestry,
+  Background,
+} from "./types";
 
 export function inBounds(c: Coord) { return c.x >= 0 && c.x < 8 && c.y >= 0 && c.y < 8; }
 export function idx(c: Coord) { return c.y * 8 + c.x; }
@@ -32,11 +43,56 @@ export function baseStats(type: PieceType) {
   }
 }
 
+function defaultOptions(type: PieceType, faction: Faction): CharacterOptions {
+  const ancestry: Ancestry = faction === "white" ? "human" : "elf";
+  let background: Background = "commoner";
+  let cls: CharacterClass = "fighter";
+  const perks: string[] = [];
+
+  switch (type) {
+    case "king":
+      cls = "artificer";
+      background = "noble";
+      perks.push("arcane_engineer");
+      break;
+    case "queen":
+      cls = "bloodmage";
+      background = "noble";
+      perks.push("blood_pact");
+      break;
+    case "knight":
+      cls = "shadow_monk";
+      background = "soldier";
+      perks.push("shadow_step");
+      break;
+    case "bishop":
+      background = "scholar";
+      break;
+    case "rook":
+      background = "noble";
+      break;
+    case "pawn":
+      background = "commoner";
+      break;
+  }
+
+  return { class: cls, ancestry, background, perks };
+}
+
 export function initialPieces(): Record<string, Piece> {
   const pieces: Record<string, Piece> = {};
   const add = (id: string, type: PieceType, faction: Faction, x: number, y: number) => {
     const s = baseStats(type);
-    pieces[id] = { id, type, faction, pos: { x, y }, hp: s.maxHp, xp: 0, cooldowns: {} };
+    pieces[id] = {
+      id,
+      type,
+      faction,
+      pos: { x, y },
+      hp: s.maxHp,
+      xp: 0,
+      cooldowns: {},
+      options: defaultOptions(type, faction),
+    };
   };
 
   // white
@@ -89,9 +145,17 @@ export function legalMoves(state: GameState, piece: Piece): Coord[] {
       return deltas.filter(inBounds);
     }
     case "knight": {
-      const ds = [{x:2,y:1},{x:2,y:-1},{x:-2,y:1},{x:-2,y:-1},{x:1,y:2},{x:1,y:-2},{x:-1,y:2},{x:-1,y:-2}]
-        .map(d => ({x: piece.pos.x + d.x, y: piece.pos.y + d.y}));
-      return ds.filter(inBounds);
+      const ds = [
+        {x:2,y:1},{x:2,y:-1},{x:-2,y:1},{x:-2,y:-1},{x:1,y:2},{x:1,y:-2},{x:-1,y:2},{x:-1,y:-2}
+      ].map(d => ({x: piece.pos.x + d.x, y: piece.pos.y + d.y}));
+      let moves = ds.filter(inBounds);
+      if (piece.options.perks.includes("shadow_step")) {
+        const extra = [-1,0,1].flatMap(dx =>
+          [-1,0,1].map(dy => ({x: piece.pos.x + dx, y: piece.pos.y + dy}))
+        ).filter(c => !(c.x===piece.pos.x && c.y===piece.pos.y));
+        moves = moves.concat(extra.filter(inBounds));
+      }
+      return moves;
     }
     case "pawn": {
       const dir = piece.faction === "white" ? -1 : 1;

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -3,6 +3,23 @@ export type Terrain = "none" | "heal" | "arcane" | "trap";
 export type PieceType = "king" | "queen" | "rook" | "bishop" | "knight" | "pawn";
 export type AiDifficulty = "easy" | "medium" | "hard";
 
+export type CharacterClass =
+  | "fighter"
+  | "artificer"
+  | "bloodmage"
+  | "shadow_monk";
+
+export type Ancestry = "human" | "elf" | "dwarf" | "orc";
+export type Background = "noble" | "scholar" | "soldier" | "commoner";
+
+export interface CharacterOptions {
+  class: CharacterClass;
+  subclass?: string;
+  ancestry: Ancestry;
+  background: Background;
+  perks: string[];
+}
+
 export type Coord = { x: number; y: number }; // x: 0-7, y: 0-7
 export type GameStatus = "idle" | "running" | "ended";
 
@@ -38,6 +55,8 @@ export interface Piece {
   xp: number;
   cooldowns: Record<string, number>;
   shield?: number;
+
+  options: CharacterOptions;
 
   // DnD statuseffecten
   poison?: number;   // doet 1 dmg bij endTurn


### PR DESCRIPTION
## Summary
- model character classes, ancestry, backgrounds, and perks on all pieces
- seed default options and new class perks like Blood Pact and Shadow Step
- show a piece's class and origin on hover

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a47d8c16888332993373b29565dffb