### PR TITLE
feat: add in-game onboarding overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,12 @@ import Board from "./components/Board";
 import HUD from "./components/HUD";
 import DMLog from "./components/DMLog";
 import AbilityBar from "./components/AbilityBar";
+import Onboarding from "./components/Onboarding";
 import { useState } from "react";
 
 export default function App() {
   const [theme, setTheme] = useState<"light" | "dark">("dark");
+  const [showOnboarding, setShowOnboarding] = useState(false);
   return (
     <div className={theme === "dark" ? "dark h-screen" : "h-screen"}>
       <div className="grid h-full grid-rows-[auto_1fr_auto] bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100 antialiased">
@@ -17,12 +19,20 @@ export default function App() {
                 DnD-geïnspireerd schaken. HP, abilities, cooldowns. Minder zout, meer vuurballen.
               </p>
             </div>
-            <button
-              className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100"
-              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-            >
-              {theme === "dark" ? "Light" : "Dark"} mode
-            </button>
+            <div className="flex gap-2">
+              <button
+                className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100"
+                onClick={() => setShowOnboarding(true)}
+              >
+                Info
+              </button>
+              <button
+                className="px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100"
+                onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+              >
+                {theme === "dark" ? "Light" : "Dark"} mode
+              </button>
+            </div>
           </div>
         </header>
 
@@ -42,6 +52,7 @@ export default function App() {
           © {new Date().getFullYear()} Wizards of the Grid. Gemaakt in React + Tailwind.
         </footer>
       </div>
+      {showOnboarding && <Onboarding onClose={() => setShowOnboarding(false)} />}
     </div>
   );
 }

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,0 +1,47 @@
+import type { CharacterClass } from "../game/types";
+
+interface OnboardingProps {
+  onClose: () => void;
+}
+
+const CLASS_INFO: Record<CharacterClass, string> = {
+  fighter: "Frontline vechter met hoge HP en directe schade.",
+  artificer: "Tinker met arcane gadgets en kortere cooldowns.",
+  bloodmage: "Gebruikt bloedmagie voor extra genezing en kracht.",
+  shadow_monk: "Sluipt door de schaduwen met mobiele, hinderlijke trucs.",
+};
+
+export default function Onboarding({ onClose }: OnboardingProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="max-h-[90vh] w-[90vw] max-w-lg overflow-y-auto rounded-2xl bg-white p-6 text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+        <h2 className="text-xl font-bold mb-4">Welkom bij Wizards of the Grid</h2>
+        <p className="mb-2 text-sm">
+          Dit spel combineert schaak met Dungeons & Dragons elementen. Elk stuk heeft HP, XP en kan abilities gebruiken met cooldowns.
+        </p>
+        <h3 className="mt-4 mb-2 font-semibold">Spelerklassen</h3>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          {Object.entries(CLASS_INFO).map(([k, v]) => (
+            <li key={k}>
+              <span className="font-medium capitalize">{k.replace("_", " ")}</span>: {v}
+            </li>
+          ))}
+        </ul>
+        <h3 className="mt-4 mb-2 font-semibold">Basis</h3>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>Start een spel via de HUD en kies je klasse.</li>
+          <li>Beweeg stukken zoals in traditioneel schaken.</li>
+          <li>Kies abilities onderaan en klik op een doelwit om ze te gebruiken.</li>
+          <li>Einde beurt: klik op "Einde beurt" in de HUD.</li>
+          <li>Pas Fog of War en AI-moeilijkheid aan in de instellingen.</li>
+        </ul>
+        <button
+          className="mt-6 px-3 py-1.5 rounded-lg bg-slate-200 hover:bg-slate-300 text-sm text-slate-900 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100"
+          onClick={onClose}
+        >
+          Sluiten
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add modal onboarding with class descriptions and basics
- expose onboarding via Info button in header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a484de53648332b191034b7a0f0821